### PR TITLE
Add endpoint url configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+)
 # Node.js wrapper for the Tenon.io API
 
 [![Build Status](https://secure.travis-ci.org/poorgeek/tenon-node.png?branch=master)](http://travis-ci.org/poorgeek/tenon-node)
@@ -11,7 +11,10 @@ Install the module with: `npm install tenon-node`
 var tenonNode = require('tenon-node');
 
 // Create an instance with your API key
-var tenonApi = new tenonNode('YOUR_API_KEY_HERE');
+var tenonApi = new tenonNode({
+    api: 'YOUR_API_KEY_HERE'
+    baseUrl: 'http://www.tenon.io' // or your private tenon instance
+});
 
 tenonApi.checkUrl('http://www.example.com', function(err, result) {
     if (err) {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-)
 # Node.js wrapper for the Tenon.io API
 
 [![Build Status](https://secure.travis-ci.org/poorgeek/tenon-node.png?branch=master)](http://travis-ci.org/poorgeek/tenon-node)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ var tenonNode = require('tenon-node');
 
 // Create an instance with your API key
 var tenonApi = new tenonNode({
-    api: 'YOUR_API_KEY_HERE'
-    baseUrl: 'http://www.tenon.io' // or your private tenon instance
+    key: 'YOUR_API_KEY_HERE'
+    endPoint: 'http://tenon.io' // or your private tenon instance
 });
 
 tenonApi.checkUrl('http://www.example.com', function(err, result) {

--- a/example/tenon-node_example.js
+++ b/example/tenon-node_example.js
@@ -5,14 +5,14 @@ var tenonNode = require('../lib/tenon-node.js');
 
 // Create an instance with your API key
 var tenonApi = new tenonNode({
-    api: 'YOUR_API_KEY_HERE'
+    key: 'YOUR_API_KEY_HERE'
 });
 
 
 // Examples
 
 // Check a URL
-tenonApi.checkUrl('http://www.google.com', {level: '1' }, function(err, result) {
+tenonApi.checkUrl('http://www.google.com', {level: 'A' }, function(err, result) {
     if (err) {
         console.error(err);
     } else {

--- a/example/tenon-node_example.js
+++ b/example/tenon-node_example.js
@@ -4,7 +4,9 @@
 var tenonNode = require('../lib/tenon-node.js');
 
 // Create an instance with your API key
-var tenonApi = new tenonNode('YOUR_API_KEY_HERE');
+var tenonApi = new tenonNode({
+    api: 'YOUR_API_KEY_HERE'
+});
 
 
 // Examples

--- a/lib/tenon-node.js
+++ b/lib/tenon-node.js
@@ -20,9 +20,10 @@ var TENON_URL = 'http://www.tenon.io/api/';
  * Tenon.io API client
  * @param {string} apiKey Tenon.io API key
  */
-var TenonIO = function(apiKey) {
-    this.credentials = {
-        key: apiKey
+var TenonIO = function(opts) {
+    this.configs = {
+        api: opts.api,
+        baseUrl: opts.baseUrl || TENON_URL
     };
 };
 module.exports = TenonIO;
@@ -36,9 +37,9 @@ module.exports = TenonIO;
  */
 TenonIO.prototype._validate = function(data, options, callback) {
 
-    data = extend(data, options, this.credentials);
+    data = extend(data, options, this.configs);
 
-    request.post(TENON_URL, {form: data}, function (err, res, body) {
+    request.post(this.configs.baseUrl, {form: data}, function (err, res, body) {
         if (err) {
             callback(err, {});
         }

--- a/lib/tenon-node.js
+++ b/lib/tenon-node.js
@@ -22,8 +22,8 @@ var TENON_URL = 'http://tenon.io/api/';
  */
 var TenonIO = function(opts) {
     this.configs = {
-        api: opts.api,
-        baseUrl: opts.baseUrl || TENON_URL
+        key: opts.key,
+        endPoint: opts.endPoint || TENON_URL
     };
 };
 module.exports = TenonIO;
@@ -39,7 +39,7 @@ TenonIO.prototype._validate = function(data, options, callback) {
 
     data = extend(data, options, this.configs);
 
-    request.post(this.configs.baseUrl, {form: data}, function (err, res, body) {
+    request.post(this.configs.endPoint, {form: data}, function (err, res, body) {
         if (err) {
             callback(err, {});
         }

--- a/lib/tenon-node.js
+++ b/lib/tenon-node.js
@@ -13,7 +13,7 @@
 var request = require('request'),
     extend = require('xtend');
 
-var TENON_URL = 'http://www.tenon.io/api/';
+var TENON_URL = 'http://tenon.io/api/';
 
 
 /**

--- a/test/tenon-node_test.js
+++ b/test/tenon-node_test.js
@@ -10,7 +10,7 @@ describe('tenon-node module:', function() {
     var API_URL = 'http://www.tenon.io';
 
     var api = new tenonNode({
-        api: 'AN_API_KEY',
+        key: 'AN_API_KEY',
         baseUrl: 'http://tenon.io'
     });
 
@@ -18,13 +18,13 @@ describe('tenon-node module:', function() {
 
         it('should accept a baseUrl', function() {
             api.checkUrl('', function() {
-                expect(api.configs.baseUrl).to.equal('http://tenon.io');
+                expect(api.configs.endPoint).to.equal('http://tenon.io/api/');
             });
         });
 
         it('should accept an API key', function() {
             api.checkUrl('', function() {
-                expect(api.configs.api).to.equal('AN_API_KEY');
+                expect(api.configs.key).to.equal('AN_API_KEY');
             });
         });
     });

--- a/test/tenon-node_test.js
+++ b/test/tenon-node_test.js
@@ -9,7 +9,25 @@ describe('tenon-node module:', function() {
 
     var API_URL = 'http://www.tenon.io';
 
-    var api = new tenonNode('AN_API_KEY');
+    var api = new tenonNode({
+        api: 'AN_API_KEY',
+        baseUrl: 'http://tenon.io'
+    });
+
+    describe('tenonNode', function() {
+
+        it('should accept a baseUrl', function() {
+            api.checkUrl('', function() {
+                expect(api.configs.baseUrl).to.equal('http://tenon.io');
+            });
+        });
+
+        it('should accept an API key', function() {
+            api.checkUrl('', function() {
+                expect(api.configs.api).to.equal('AN_API_KEY');
+            });
+        });
+    });
 
     describe('checkUrl', function() {
         it('should return an error if a URL is not specified', function() {
@@ -99,7 +117,6 @@ describe('tenon-node module:', function() {
             });
         });
     });
-
 
     describe('checkFragment', function() {
         it('should return an error if a block of HTML is not specified', function() {

--- a/test/tenon-node_test.js
+++ b/test/tenon-node_test.js
@@ -16,7 +16,7 @@ describe('tenon-node module:', function() {
 
     describe('tenonNode', function() {
 
-        it('should accept a baseUrl', function() {
+        it('should accept a endPoint', function() {
             api.checkUrl('', function() {
                 expect(api.configs.endPoint).to.equal('http://tenon.io/api/');
             });


### PR DESCRIPTION
This PR adds a new option and modifies how the node module is configured. I've updated the constructor function to expect a configs/options object which will permit future configuration extensions. This done so that the constructor could accept both an api key and baseUrl. 

Some "Enterprise" customers can host their own Tenon VMs. These customer may wish to use their self host servers rather than the Saas server endpoint.

To test:
- checkout the branch
- run the unit tests
- run the examples
- verify the updates to th README.md

Sample usage:

``` js
var tenonNode = require('tenon-node');

// Create an instance with your API key
var tenonApi = new tenonNode({
    key: 'YOUR_API_KEY_HERE'
    endPoint: 'http://tenon.io' // or your private tenon instance
});

tenonApi.checkUrl('http://www.example.com', function(err, result) {
    if (err) {
        console.error(err);
    } else {
        console.log('Tenon.checkUrl', result);
    }
});

```
